### PR TITLE
Refine chatbot page and restore docs

### DIFF
--- a/assets/coolservice_logo.svg
+++ b/assets/coolservice_logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+  <rect width="200" height="100" fill="#0080ff"/>
+  <g stroke="white" stroke-width="4">
+    <line x1="100" y1="20" x2="100" y2="80"/>
+    <line x1="70" y1="50" x2="130" y2="50"/>
+    <line x1="80" y1="30" x2="120" y2="70"/>
+    <line x1="80" y1="70" x2="120" y2="30"/>
+  </g>
+  <text x="100" y="95" font-size="20" font-family="Arial" fill="white" text-anchor="middle">Cool Service</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cool Service Chatbot</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      text-align: center;
+      background-color: #f6f6f6;
+      margin: 0;
+    }
+    header {
+      background-color: #0080ff;
+      padding: 20px 0;
+    }
+    .logo {
+      width: 200px;
+    }
+    main {
+      padding: 20px;
+    }
+    iframe {
+      width: 100%;
+      height: 600px;
+      border: none;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <img class="logo" src="assets/coolservice_logo.svg" alt="Cool Service Logo" />
+  </header>
+  <main>
+    <h1>Chat with Cool Service Assistant</h1>
+    <p>We specialize in refrigeration and air conditioning installations.</p>
+    <iframe src="http://localhost:8501" loading="lazy"></iframe>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple logo in SVG format
- create a friendly landing page embedding the Streamlit chatbot
- restore initial documentation state

## Testing
- `python -m py_compile app.py`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6866e92310408332ad32822e2d396c81